### PR TITLE
(#1) feat: add pricing page for subscription plans

### DIFF
--- a/docs/pricing.html
+++ b/docs/pricing.html
@@ -259,10 +259,10 @@
     const params = new URLSearchParams(window.location.search);
     const userId = params.get('user_id');
 
-    // Lemon Squeezy 체크아웃 URL (실제 상품 URL로 교체 필요)
+    // Lemon Squeezy 체크아웃 URL
     const CHECKOUT_URLS = {
-      monthly: 'https://YOUR_STORE.lemonsqueezy.com/checkout/buy/MONTHLY_VARIANT_ID',
-      yearly: 'https://YOUR_STORE.lemonsqueezy.com/checkout/buy/YEARLY_VARIANT_ID'
+      monthly: 'https://copy-money.lemonsqueezy.com/checkout/buy/da7733f3-9b6d-4b38-8536-ccb7920e42b8',
+      yearly: 'https://copy-money.lemonsqueezy.com/checkout/buy/27899a37-ea2a-4470-b5e2-6a0e3bdd27fb'
     };
 
     document.getElementById('monthlyBtn').addEventListener('click', (e) => {


### PR DESCRIPTION
Closes #1

## Changes
- Add pricing page with monthly (₩4,900) and yearly (₩49,000) plans
- Integrate Lemon Squeezy checkout
- 17% discount for yearly subscription

## Files
- `docs/pricing.html` - New pricing page with checkout integration