### PR TITLE
(#7) docs: add nginx setup scripts and troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# revu-docs
+
+REVU 서비스의 정적 문서 페이지 모음입니다.
+
+## 사이트
+
+- **URL**: https://revu.copy-money.com
+- **호스팅**: WSL2 + Nginx + Let's Encrypt
+
+## 페이지 목록
+
+| 경로 | 파일 | 설명 |
+|------|------|------|
+| `/` | `docs/index.html` | 이메일 인증 완료 페이지 |
+| `/pricing` | `docs/pricing.html` | 요금제 안내 |
+| `/privacy` | `docs/privacy.html` | 개인정보처리방침 |
+| `/terms` | `docs/terms.html` | 이용약관 |
+
+## 서버 설정
+
+- **Nginx 설정**: `/etc/nginx/sites-available/revu.copy-money.com`
+- **SSL 인증서**: `/etc/letsencrypt/live/revu.copy-money.com/` (Let's Encrypt, 자동 갱신)
+- **Document Root**: `/home/seung/sg/revu-docs/docs`
+
+## 스크립트
+
+| 파일 | 설명 |
+|------|------|
+| `scripts/setup-nginx.sh` | Nginx + SSL 초기 설정 (WSL에서 실행) |
+| `scripts/wsl-port-forward.sh` | WSL2 포트포워딩 추가/제거/상태 확인 |
+| `scripts/wsl2-portforward.ps1` | Windows 포트포워딩 자동 업데이트 |
+| `scripts/register-portforward-task.ps1` | Windows 로그인 시 자동 포트포워딩 등록 (PowerShell 관리자) |
+
+## 문제 해결
+
+[trouble-shooting.md](./trouble-shooting.md) 참고

--- a/scripts/register-portforward-task.ps1
+++ b/scripts/register-portforward-task.ps1
@@ -1,0 +1,34 @@
+# Register Windows Scheduled Task for WSL2 Port Forwarding
+# Run this script ONCE in PowerShell (Admin) to set up auto-run at login
+
+$scriptPath = "C:\wsl2-portforward.ps1"
+
+# Copy script to C:\ for stable path
+$wslScriptPath = (wsl -d Ubuntu -e wslpath -w "/home/seung/sg/revu-docs/scripts/wsl2-portforward.ps1")
+Copy-Item $wslScriptPath $scriptPath -Force
+
+$action = New-ScheduledTaskAction `
+    -Execute "powershell.exe" `
+    -Argument "-ExecutionPolicy Bypass -WindowStyle Hidden -File `"$scriptPath`""
+
+$trigger = New-ScheduledTaskTrigger -AtLogOn
+
+$principal = New-ScheduledTaskPrincipal `
+    -UserId "$env:USERNAME" `
+    -RunLevel Highest
+
+$settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable
+
+Register-ScheduledTask `
+    -TaskName "WSL2 Port Forward" `
+    -Action $action `
+    -Trigger $trigger `
+    -Principal $principal `
+    -Settings $settings `
+    -Force
+
+Write-Host "`n[DONE] 'WSL2 Port Forward' 작업이 등록되었습니다." -ForegroundColor Green
+Write-Host "Windows 로그인 시 자동으로 포트포워딩이 업데이트됩니다." -ForegroundColor Cyan

--- a/scripts/setup-nginx.sh
+++ b/scripts/setup-nginx.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# revu.copy-money.com Nginx + SSL 설정 스크립트
+set -euo pipefail
+
+DOMAIN="revu.copy-money.com"
+DOC_ROOT="/home/seung/sg/revu-docs/docs"
+CONF_FILE="/etc/nginx/sites-available/${DOMAIN}"
+
+echo "=== [1/5] Document root 권한 설정 ==="
+chmod o+x /home/seung
+
+echo "=== [2/5] Nginx 설정 파일 생성 ==="
+sudo tee "${CONF_FILE}" > /dev/null <<'EOF'
+server {
+    listen 80;
+    server_name revu.copy-money.com;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name revu.copy-money.com;
+    root /home/seung/sg/revu-docs/docs;
+    index index.html;
+
+    ssl_certificate /etc/letsencrypt/live/revu.copy-money.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/revu.copy-money.com/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location / {
+        try_files $uri $uri.html $uri/ =404;
+    }
+
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+    gzip_min_length 256;
+
+    location ~* \.(jpg|jpeg|png|gif|ico|css|js|svg|woff|woff2|ttf|eot)$ {
+        expires 30d;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location ~ /\. {
+        deny all;
+    }
+}
+EOF
+
+echo "=== [3/5] Sites-enabled 심볼릭 링크 ==="
+cd /etc/nginx/sites-enabled
+sudo ln -sf "../sites-available/${DOMAIN}" .
+
+echo "=== [4/5] SSL 인증서 발급 (certbot) ==="
+sudo certbot certonly --nginx -d "${DOMAIN}"
+
+echo "=== [5/5] Nginx 테스트 & 재시작 ==="
+sudo nginx -t && sudo systemctl restart nginx
+
+echo ""
+echo "========================================"
+echo " 완료! https://${DOMAIN} 접속 확인"
+echo "========================================"

--- a/scripts/wsl-port-forward.sh
+++ b/scripts/wsl-port-forward.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# WSL2 포트 포워딩 자동화 스크립트
+# Windows의 netsh를 사용하여 호스트 -> WSL2 포트 포워딩 설정
+
+set -euo pipefail
+
+# ======== 설정 ========
+PORTS=(80 443)
+# ======================
+
+WSL_IP=$(hostname -I | awk '{print $1}')
+
+if [ -z "$WSL_IP" ]; then
+    echo "[ERROR] WSL IP를 가져올 수 없습니다."
+    exit 1
+fi
+
+echo "WSL IP: $WSL_IP"
+echo "포워딩 포트: ${PORTS[*]}"
+echo ""
+
+show_status() {
+    echo "=== 현재 포트 프록시 상태 ==="
+    netsh.exe interface portproxy show v4tov4 2>/dev/null | sed 's/\r$//'
+    echo ""
+}
+
+add_forwarding() {
+    echo "=== 포트 포워딩 추가 ==="
+    for PORT in "${PORTS[@]}"; do
+        echo "  [+] 0.0.0.0:${PORT} -> ${WSL_IP}:${PORT}"
+        netsh.exe interface portproxy add v4tov4 \
+            listenport="$PORT" listenaddress=0.0.0.0 \
+            connectport="$PORT" connectaddress="$WSL_IP" 2>/dev/null
+    done
+    echo ""
+
+    echo "=== 방화벽 규칙 추가 ==="
+    PORTS_STR=$(IFS=,; echo "${PORTS[*]}")
+    powershell.exe -Command "
+        Remove-NetFirewallRule -DisplayName 'WSL2 Port Forward' -ErrorAction SilentlyContinue
+        New-NetFirewallRule -DisplayName 'WSL2 Port Forward' -Direction Inbound -Action Allow -Protocol TCP -LocalPort ${PORTS_STR}
+    " 2>/dev/null
+    echo "  [+] 방화벽 인바운드 규칙 추가 완료 (TCP: ${PORTS_STR})"
+    echo ""
+}
+
+remove_forwarding() {
+    echo "=== 포트 포워딩 제거 ==="
+    for PORT in "${PORTS[@]}"; do
+        echo "  [-] 0.0.0.0:${PORT}"
+        netsh.exe interface portproxy delete v4tov4 \
+            listenport="$PORT" listenaddress=0.0.0.0 2>/dev/null || true
+    done
+    powershell.exe -Command "
+        Remove-NetFirewallRule -DisplayName 'WSL2 Port Forward' -ErrorAction SilentlyContinue
+    " 2>/dev/null
+    echo "  [-] 방화벽 규칙 제거 완료"
+    echo ""
+}
+
+usage() {
+    echo "사용법: $0 {add|remove|status}"
+    echo ""
+    echo "  add     포트 포워딩 추가"
+    echo "  remove  포트 포워딩 제거"
+    echo "  status  현재 상태 확인"
+}
+
+case "${1:-add}" in
+    add)    add_forwarding; show_status ;;
+    remove) remove_forwarding; show_status ;;
+    status) show_status ;;
+    *)      usage ;;
+esac

--- a/scripts/wsl2-portforward.ps1
+++ b/scripts/wsl2-portforward.ps1
@@ -1,0 +1,41 @@
+# WSL2 Port Forwarding Auto-Update Script
+# Ports to forward
+$ports = @(80, 443)
+
+# Get WSL2 IP
+$wslIp = (wsl -d Ubuntu -e hostname -I).Trim().Split(" ")[0]
+
+if (-not $wslIp) {
+    Write-Host "[ERROR] WSL2 IP를 가져올 수 없습니다." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "[INFO] WSL2 IP: $wslIp" -ForegroundColor Cyan
+
+# Clear existing port proxy rules for these ports
+foreach ($port in $ports) {
+    netsh interface portproxy delete v4tov4 listenport=$port listenaddress=0.0.0.0 2>$null
+}
+
+# Add new port proxy rules
+foreach ($port in $ports) {
+    netsh interface portproxy add v4tov4 listenport=$port listenaddress=0.0.0.0 connectport=$port connectaddress=$wslIp
+    Write-Host "[OK] Port $port -> ${wslIp}:${port}" -ForegroundColor Green
+}
+
+# Ensure firewall rules exist (idempotent)
+$rules = @(
+    @{ Name = "WSL2 HTTP";  Port = 80  },
+    @{ Name = "WSL2 HTTPS"; Port = 443 }
+)
+
+foreach ($rule in $rules) {
+    $existing = netsh advfirewall firewall show rule name=$($rule.Name) 2>$null
+    if ($existing -notmatch "Rule Name") {
+        netsh advfirewall firewall add rule name=$($rule.Name) dir=in action=allow protocol=TCP localport=$($rule.Port)
+        Write-Host "[OK] Firewall rule added: $($rule.Name)" -ForegroundColor Green
+    }
+}
+
+Write-Host "`n[DONE] Port forwarding updated." -ForegroundColor Yellow
+netsh interface portproxy show all

--- a/trouble-shooting.md
+++ b/trouble-shooting.md
@@ -1,0 +1,116 @@
+# Troubleshooting
+
+## revu.copy-money.com 서버 설정 가이드
+
+WSL2 환경에서 Nginx + Let's Encrypt로 서브도메인을 설정하는 과정의 트러블슈팅 기록입니다.
+
+---
+
+## 환경
+
+- **OS**: WSL2 (Ubuntu) on Windows
+- **Web Server**: Nginx 1.18.0
+- **SSL**: Let's Encrypt (certbot)
+- **포트포워딩**: Windows netsh → WSL2 → Nginx
+
+---
+
+## 발생했던 문제들
+
+### 1. certbot이 nginx 설정을 자동으로 업데이트하지 못함
+
+**증상**: certbot 실행 후 `Could not install certificate` 오류
+
+**원인**: `sites-enabled`에 심볼릭 링크가 없어 certbot이 nginx 서버 블록을 찾지 못함
+
+**해결**: 인증서를 발급 후 nginx 설정에 수동으로 SSL 블록 추가
+```nginx
+ssl_certificate /etc/letsencrypt/live/revu.copy-money.com/fullchain.pem;
+ssl_certificate_key /etc/letsencrypt/live/revu.copy-money.com/privkey.pem;
+include /etc/letsencrypt/options-ssl-nginx.conf;
+ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+```
+
+---
+
+### 2. revu.copy-money.com 요청이 copy-money.com으로 라우팅됨
+
+**증상**: nginx 로그에서 `host: revu.copy-money.com`인데 `server: copy-money.com`으로 처리됨
+
+**원인**: `sites-enabled`에 `revu.copy-money.com` 심볼릭 링크가 없어 nginx가 서버 블록을 인식하지 못함
+
+**해결**:
+```bash
+cd /etc/nginx/sites-enabled
+sudo ln -sf ../sites-available/revu.copy-money.com .
+sudo systemctl restart nginx
+```
+
+---
+
+### 3. 긴 경로 복사-붙여넣기 시 줄바꿈 문제
+
+**증상**: `sudo ln -sf /etc/nginx/sites-available/revu.copy-money.com /etc/nginx/sites-enabled/revu.copy-money.com` 명령이 터미널에서 잘림
+
+**해결**: `cd`로 이동 후 상대경로 사용
+```bash
+cd /etc/nginx/sites-enabled
+sudo ln -sf ../sites-available/revu.copy-money.com .
+```
+
+---
+
+### 4. Nginx 403 Forbidden (Document Root 접근 불가)
+
+**증상**: SSL 설정 후 모든 요청에서 404 반환
+
+**원인**: `/home/seung/` 디렉토리 권한이 `750`이라 www-data(nginx)가 접근 불가
+
+**해결**:
+```bash
+chmod o+x /home/seung
+```
+
+---
+
+## Nginx 설정 파일
+
+```nginx
+# /etc/nginx/sites-available/revu.copy-money.com
+
+server {
+    listen 80;
+    server_name revu.copy-money.com;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name revu.copy-money.com;
+    root /home/seung/sg/revu-docs/docs;
+    index index.html;
+
+    ssl_certificate /etc/letsencrypt/live/revu.copy-money.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/revu.copy-money.com/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location / {
+        try_files $uri $uri.html $uri/ =404;
+    }
+}
+```
+
+---
+
+## WSL2 포트포워딩
+
+WSL2 IP는 재시작마다 변경되므로 포트포워딩을 다시 설정해야 할 수 있음:
+
+```bash
+~/wsl-port-forward.sh add
+```
+
+**공유기 포트포워딩**: 외부 80, 443 → Windows PC 내부 IP (192.168.55.103)
+
+**Windows → WSL**: `netsh portproxy` 로 80, 443 → WSL IP 포워딩


### PR DESCRIPTION
## Summary

- Add README.md with site overview, server config, and script references
- Add trouble-shooting.md documenting WSL2 + Nginx + Let's Encrypt setup issues
- Add scripts/ directory with all related setup scripts

## Changes

- `README.md` - site overview, page list, server config, script table
- `trouble-shooting.md` - 4 issues documented with solutions
- `scripts/setup-nginx.sh` - Nginx + SSL initial setup
- `scripts/wsl-port-forward.sh` - WSL2 port forwarding management
- `scripts/wsl2-portforward.ps1` - Windows port forwarding auto-update
- `scripts/register-portforward-task.ps1` - Windows scheduled task registration

Closes #7